### PR TITLE
Added ciManagement for SonarQube build analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,23 @@
         <tag>HEAD</tag>
     </scm>
 
+    <ciManagement>
+        <system>jenkins</system>
+        <url>http://cis.maccio-ch.homelinux.net/jenkins/job/TUTORIALS-CamelAtWork/</url>
+        <notifiers>
+          <notifier>
+            <type>mail</type>
+            <sendOnError>true</sendOnError>
+            <sendOnFailure>true</sendOnFailure>
+            <sendOnSuccess>true</sendOnSuccess>
+            <sendOnWarning>false</sendOnWarning>
+            <configuration>
+              <address>marco.maccio@marmac.name</address>
+            </configuration>
+          </notifier>
+        </notifiers>
+    </ciManagement>
+
     <distributionManagement>
 
         <snapshotRepository>


### PR DESCRIPTION
Added the ciManagement section in order to have the build stability
analysis by Sonarqube.
